### PR TITLE
Checking if function failed before deciding to progress checkpointer

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubListener.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                     {
                         foreach (var task in failedTasks)
                         {
-                            _logger.LogError(task.Exception, "Task failed while trying to process single message/event");
+                            _logger.LogInformation(task.Exception, "Task failed while trying to process single message/event");
                         }
 
                         functionExceptionOccurred = true;
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                         var functionResult = await _executor.TryExecuteAsync(input, _cts.Token);
                         if (functionResult.Exception != null) 
                         {
-                            _logger.LogError(functionResult.Exception, $"Task failed while trying to process {triggerInput.Events.Length} messages/events");
+                            _logger.LogInformation(functionResult.Exception, $"Task failed while trying to process {triggerInput.Events.Length} messages/events");
                             functionExceptionOccurred = true;
                         }
                     }

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubListener.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                     {
                         foreach (var task in failedTasks)
                         {
-                            _logger.LogInformation(task.Exception, "Task failed while trying to process single message/event");
+                            _logger.LogError(task.Exception, "Task failed while trying to process single message/event");
                         }
 
                         functionExceptionOccurred = true;
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                         var functionResult = await _executor.TryExecuteAsync(input, _cts.Token);
                         if (functionResult.Exception != null) 
                         {
-                            _logger.LogInformation(functionResult.Exception, $"Task failed while trying to process {triggerInput.Events.Length} messages/events");
+                            _logger.LogError(functionResult.Exception, $"Task failed while trying to process {triggerInput.Events.Length} messages/events");
                             functionExceptionOccurred = true;
                         }
                     }


### PR DESCRIPTION
When a function app fails internally, the EventHubTrigger will throw away events, because the exception is treated as user code. 

See:

https://github.com/Azure/azure-webjobs-sdk/issues/2432
https://github.com/Azure/azure-functions-host/issues/5240

This PR prevents events getting thrown away, by not progressing the checkpointer in case of exceptions. Code assumes, that the user will handle ***user*** exceptions manually in the Run function.

Code should be refactored to allow the user to choose the flow, in host.json or the local settings file.

MyGet package for this branch:

https://www.myget.org/feed/xzuttz/package/nuget/Microsoft.Azure.WebJobs.Extensions.EventHubs